### PR TITLE
feat: Implement pm init command and core functionality

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+use crate::config::{get_config_path, save_config, Config};
+use crate::constants::*;
+use crate::display::*;
+use crate::error::PmError;
+use anyhow::Result;
+
+pub async fn handle_init() -> Result<()> {
+    let config_path = get_config_path()?;
+
+    if config_path.exists() {
+        display_success(&format!("{} is already initialized", APP_NAME.to_uppercase()));
+        println!("📁 Configuration file: {}", config_path.display());
+        println!("\n💡 To reinitialize, delete the config file first:");
+        println!("   rm {}", config_path.display());
+        return Ok(());
+    }
+
+    println!("🚀 Initializing {}...\n", APP_NAME.to_uppercase());
+
+    let github_username = match inquire::Text::new("GitHub username:").prompt() {
+        Ok(username) => username,
+        Err(e) => {
+            display_error("Failed to get GitHub username", &e.to_string());
+            display_info("You can also set this later in the config file");
+            return Err(PmError::InitializationFailed.into());
+        }
+    };
+
+    let projects_root_dir_str = match inquire::Text::new("Projects root directory path:")
+        .with_default(DEFAULT_WORKSPACE_DIR)
+        .prompt()
+    {
+        Ok(path) => path,
+        Err(e) => {
+            display_error("Failed to get projects root directory", &e.to_string());
+            return Err(PmError::InitializationFailed.into());
+        }
+    };
+
+    let projects_root_dir = PathBuf::from(shellexpand::tilde(&projects_root_dir_str).to_string());
+
+    // Validate and create the projects root directory if it doesn't exist
+    if !projects_root_dir.exists() {
+        println!("📁 Creating projects root directory: {}", projects_root_dir.display());
+        if let Err(e) = std::fs::create_dir_all(&projects_root_dir) {
+            display_error("Failed to create directory", &e.to_string());
+            println!("   Path: {}", projects_root_dir.display());
+            return Err(PmError::DirectoryCreationFailed.into());
+        }
+    }
+
+    let config = Config {
+        github_username: github_username.clone(),
+        projects_root_dir: projects_root_dir.clone(),
+        ..Default::default()
+    };
+
+    save_config(&config).await?;
+
+    display_init_success(&github_username, &projects_root_dir, &config_path);
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod init;
+pub mod project;
+pub mod tag;

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -1,0 +1,280 @@
+use std::path::PathBuf;
+use chrono::Utc;
+use uuid::Uuid;
+use crate::config::{load_config, save_config, Config};
+use crate::constants::*;
+use crate::display::*;
+use crate::error::PmError;
+use crate::utils::get_last_git_commit_time;
+use crate::validation::{validate_path, parse_time_duration};
+use crate::Project;
+use anyhow::Result;
+use std::collections::HashSet;
+
+pub async fn handle_add(path: &PathBuf, name: &Option<String>, tags: &[String], description: &Option<String>) -> Result<()> {
+    let mut config = load_config().await?;
+
+    let resolved_path = if path.is_absolute() {
+        path.clone()
+    } else {
+        config.projects_root_dir.join(path)
+    };
+
+    let absolute_path = validate_path(&resolved_path)?;
+
+    // Check for duplicate projects
+    if config.projects.values().any(|p| p.path == absolute_path) {
+        display_error(ERROR_DUPLICATE_PROJECT, &format!("at path: {}", absolute_path.display()));
+        display_info(SUGGESTION_USE_PM_LS);
+        return Err(PmError::DuplicateProject.into());
+    }
+
+    let project_name = name.clone().unwrap_or_else(|| {
+        absolute_path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unnamed-project")
+            .to_string()
+    });
+
+    // Check for duplicate project names
+    if config.projects.values().any(|p| p.name == project_name) {
+        display_error(ERROR_DUPLICATE_PROJECT, &format!("with name '{}'", project_name));
+        display_info(&format!("Use a different name with: pm add {} --name <new-name>", path.display()));
+        return Err(PmError::DuplicateProject.into());
+    }
+
+    println!("📂 Adding project at: {}", absolute_path.display());
+
+    let git_updated_at = match get_last_git_commit_time(&absolute_path) {
+        Ok(time) => time,
+        Err(_) => {
+            display_warning("Not a Git repository or no commits found");
+            None
+        }
+    };
+
+    let project = Project {
+        id: Uuid::new_v4(),
+        name: project_name.clone(),
+        path: absolute_path,
+        tags: tags.to_vec(),
+        description: description.clone(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        git_updated_at,
+    };
+
+    config.add_project(project);
+    save_config(&config).await?;
+
+    display_project_added(&project_name, tags);
+    Ok(())
+}
+
+pub async fn handle_list(tags: &[String], tags_any: &[String], recent: &Option<String>, limit: &Option<usize>, detailed: bool) -> Result<()> {
+    let mut config = load_config().await?;
+
+    if config.projects.is_empty() {
+        display_no_projects();
+        return Ok(());
+    }
+
+    let project_ids: Vec<uuid::Uuid> = config.projects.keys().cloned().collect();
+    
+    // Update git_updated_at for projects in the background
+    update_git_times_by_ids(&project_ids).await;
+
+    // Get filtered project data
+    let filtered_project_data = get_filtered_project_data(&config, tags, tags_any, recent)?;
+
+    if filtered_project_data.is_empty() {
+        display_no_matches();
+        return Ok(());
+    }
+
+    // Apply limit
+    let limited_project_data = if let Some(limit_count) = limit {
+        filtered_project_data.into_iter().take(*limit_count).collect()
+    } else {
+        filtered_project_data
+    };
+
+    display_project_list_header(limited_project_data.len());
+
+    for (project, last_accessed, access_count) in limited_project_data {
+        if detailed {
+            display_project_detailed(&project, last_accessed, access_count);
+        } else {
+            display_project_simple(&project, last_accessed);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn handle_switch(config: &mut Config, name: &str, no_editor: bool) -> Result<()> {
+    if config.projects.is_empty() {
+        display_no_projects();
+        return Err(PmError::NoProjectsFound.into());
+    }
+
+    if let Some(project) = config.find_project_by_name(name) {
+        let project_id = project.id;
+        let project_name = project.name.clone();
+        let project_path = project.path.clone();
+
+        // Check if project path still exists
+        if !project_path.exists() {
+            display_error(ERROR_PROJECT_NOT_FOUND, &format!("path no longer exists: {}", project_path.display()));
+            println!("\n💡 Suggestions:");
+            println!("  - Update the project path");
+            println!("  - Remove the project: pm project remove {}", project_name);
+            return Err(PmError::ProjectPathNotFound.into());
+        }
+
+        // Record access before switching
+        config.record_project_access(project_id);
+        
+        // Get access info for display
+        let (last_accessed, access_count) = config.get_project_access_info(project_id);
+        
+        display_switch_info(&project_name, access_count, last_accessed);
+        
+        if let Err(e) = std::env::set_current_dir(&project_path) {
+            display_error(ERROR_DIRECTORY_CHANGE, &e.to_string());
+            println!("   Path: {}", project_path.display());
+            return Err(PmError::DirectoryChangeFailed.into());
+        }
+        
+        // Save config with updated access tracking
+        if let Err(e) = save_config(&config).await {
+            display_warning(&format!("Failed to save access tracking: {}", e));
+            // Continue anyway, don't fail the switch operation
+        }
+        
+        display_switch_success(&project_path, no_editor);
+
+        if !no_editor {
+            let mut cmd = std::process::Command::new(DEFAULT_EDITOR);
+            match cmd.status() {
+                Ok(status) => {
+                    if !status.success() {
+                        display_warning(&format!("Editor exited with status: {}", status));
+                    }
+                },
+                Err(e) => {
+                    display_editor_error(&e.to_string());
+                }
+            }
+        }
+
+        Ok(())
+    } else {
+        display_error(ERROR_PROJECT_NOT_FOUND, &format!("'{}'", name));
+        
+        let suggestions = suggest_similar_projects(&config, name);
+        display_suggestions(&suggestions);
+        
+        Err(PmError::ProjectNotFound.into())
+    }
+}
+
+fn suggest_similar_projects(config: &Config, target: &str) -> Vec<String> {
+    config.projects.values()
+        .map(|p| &p.name)
+        .filter(|name| {
+            // Simple similarity check - contains substring or starts with same chars
+            name.to_lowercase().contains(&target.to_lowercase()) ||
+            target.to_lowercase().contains(&name.to_lowercase()) ||
+            name.chars().take(3).collect::<String>().to_lowercase() == 
+            target.chars().take(3).collect::<String>().to_lowercase()
+        })
+        .map(|s| s.clone())
+        .collect()
+}
+
+async fn update_git_times_by_ids(project_ids: &[uuid::Uuid]) {
+    use crate::config::load_config;
+    use crate::constants::GIT_UPDATE_INTERVAL_HOURS;
+    
+    for &project_id in project_ids {
+        tokio::spawn(async move {
+            if let Ok(config) = load_config().await {
+                if let Some(project) = config.projects.get(&project_id) {
+                    let needs_update = project.git_updated_at.is_none() || 
+                                       (Utc::now() - project.git_updated_at.unwrap()).num_hours() >= GIT_UPDATE_INTERVAL_HOURS;
+                    if needs_update {
+                        let project_path = project.path.clone();
+                        if let Ok(Some(git_time)) = get_last_git_commit_time(&project_path) {
+                            if let Ok(mut config) = load_config().await {
+                                if let Some(p) = config.projects.get_mut(&project_id) {
+                                    p.git_updated_at = Some(git_time);
+                                    let _ = save_config(&config).await;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn get_filtered_project_data(config: &Config, tags: &[String], tags_any: &[String], recent: &Option<String>) -> Result<Vec<(Project, Option<chrono::DateTime<chrono::Utc>>, u32)>> {
+    let mut project_data: Vec<(Project, Option<chrono::DateTime<chrono::Utc>>, u32)> = config.projects.values()
+        .filter(|project| {
+            // Tags filter (AND logic - all tags must match)
+            if !tags.is_empty() {
+                let project_tags: HashSet<String> = project.tags.iter().cloned().collect();
+                if !tags.iter().all(|tag| project_tags.contains(tag)) {
+                    return false;
+                }
+            }
+
+            // Tags any filter (OR logic - any tag can match)
+            if !tags_any.is_empty() {
+                let project_tags: HashSet<String> = project.tags.iter().cloned().collect();
+                if !tags_any.iter().any(|tag| project_tags.contains(tag)) {
+                    return false;
+                }
+            }
+
+            // Recent filter
+            if let Some(recent_str) = recent {
+                match parse_time_duration(recent_str) {
+                    Ok(duration) => {
+                        let cutoff = Utc::now() - duration;
+                        let last_activity = project.git_updated_at.unwrap_or(project.updated_at);
+                        if last_activity < cutoff {
+                            return false;
+                        }
+                    },
+                    Err(_) => {
+                        display_warning(&format!("Invalid time format: {}. Using default of {} days.", recent_str, DEFAULT_RECENT_DAYS));
+                        let cutoff = Utc::now() - chrono::Duration::days(DEFAULT_RECENT_DAYS);
+                        let last_activity = project.git_updated_at.unwrap_or(project.updated_at);
+                        if last_activity < cutoff {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            true
+        })
+        .cloned()
+        .map(|project| {
+            let (last_accessed, access_count) = config.get_project_access_info(project.id);
+            (project, last_accessed, access_count)
+        })
+        .collect();
+
+    // Sort projects: git_updated_at (later), updated_at, created_at
+    project_data.sort_by(|a, b| {
+        b.0.git_updated_at.cmp(&a.0.git_updated_at)
+            .then_with(|| b.0.updated_at.cmp(&a.0.updated_at))
+            .then_with(|| b.0.created_at.cmp(&a.0.created_at))
+    });
+
+    Ok(project_data)
+}

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -1,0 +1,59 @@
+use crate::config::{load_config, save_config};
+use crate::tag_commands::{add_tags, remove_tags, list_tags, show_tags};
+use crate::display::display_error;
+use crate::error::PmError;
+use anyhow::Result;
+
+pub async fn handle_tag_add(project_name: &str, tags: &[String]) -> Result<()> {
+    let mut config = load_config().await?;
+    
+    match add_tags(project_name, tags, &mut config).await {
+        Ok(_) => {
+            save_config(&config).await?;
+            Ok(())
+        }
+        Err(e) => {
+            display_error("Failed to add tags", &e.to_string());
+            Err(PmError::TagOperationFailed.into())
+        }
+    }
+}
+
+pub async fn handle_tag_remove(project_name: &str, tags: &[String]) -> Result<()> {
+    let mut config = load_config().await?;
+    
+    match remove_tags(project_name, tags, &mut config).await {
+        Ok(_) => {
+            save_config(&config).await?;
+            Ok(())
+        }
+        Err(e) => {
+            display_error("Failed to remove tags", &e.to_string());
+            Err(PmError::TagOperationFailed.into())
+        }
+    }
+}
+
+pub async fn handle_tag_list() -> Result<()> {
+    let config = load_config().await?;
+    
+    match list_tags(&config).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            display_error("Failed to list tags", &e.to_string());
+            Err(PmError::TagOperationFailed.into())
+        }
+    }
+}
+
+pub async fn handle_tag_show(project_name: Option<&str>) -> Result<()> {
+    let config = load_config().await?;
+    
+    match show_tags(project_name, &config).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            display_error("Failed to show tags", &e.to_string());
+            Err(PmError::TagOperationFailed.into())
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::{Project, MachineMetadata};
+use crate::constants::*;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -17,8 +18,8 @@ pub struct Config {
 
 pub fn get_config_path() -> Result<PathBuf> {
     let config_dir = dirs::config_dir().context("Failed to find config directory")?;
-    let pm_dir = config_dir.join("pm");
-    Ok(pm_dir.join("config.json"))
+    let pm_dir = config_dir.join(APP_NAME);
+    Ok(pm_dir.join(CONFIG_FILENAME))
 }
 
 pub async fn load_config() -> Result<Config> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,39 @@
+// Application constants
+pub const APP_NAME: &str = "pm";
+pub const CONFIG_FILENAME: &str = "config.json";
+
+// Default values
+pub const DEFAULT_WORKSPACE_DIR: &str = "~/workspace";
+pub const DEFAULT_EDITOR: &str = "hx";
+pub const DEFAULT_RECENT_DAYS: i64 = 7;
+
+// Time constants
+pub const GIT_UPDATE_INTERVAL_HOURS: i64 = 1;
+
+// Display constants
+pub const PROJECT_NAME_WIDTH: usize = 20;
+pub const PROJECT_TAGS_WIDTH: usize = 30;
+pub const PROJECT_TIME_WIDTH: usize = 20;
+
+// Error messages
+pub const ERROR_CONFIG_LOAD: &str = "Failed to load configuration";
+pub const ERROR_CONFIG_SAVE: &str = "Failed to save configuration";
+pub const ERROR_INVALID_PATH: &str = "Invalid project path";
+pub const ERROR_PROJECT_NOT_FOUND: &str = "Project not found";
+pub const ERROR_DUPLICATE_PROJECT: &str = "Project already exists";
+pub const ERROR_DIRECTORY_CHANGE: &str = "Failed to change directory";
+pub const ERROR_EDITOR_LAUNCH: &str = "Failed to launch editor";
+
+// Success messages
+pub const SUCCESS_PROJECT_ADDED: &str = "Project added successfully";
+pub const SUCCESS_PROJECT_SWITCHED: &str = "Project switched";
+pub const SUCCESS_PM_INITIALIZED: &str = "PM initialized successfully";
+
+// Suggestion messages
+pub const SUGGESTION_CHECK_PATH: &str = "Check if the path is correct";
+pub const SUGGESTION_CREATE_DIRECTORY: &str = "Create the directory first";
+pub const SUGGESTION_USE_PM_LS: &str = "Use 'pm ls' to see all available projects";
+pub const SUGGESTION_ADD_FIRST_PROJECT: &str = "Add your first project with: pm add <path>";
+pub const SUGGESTION_INSTALL_HELIX: &str = "Install Helix editor: https://helix-editor.com/";
+pub const SUGGESTION_USE_NO_EDITOR: &str = "Use --no-editor flag to skip editor";
+pub const SUGGESTION_SET_EDITOR_ENV: &str = "Set EDITOR environment variable to your preferred editor";

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,181 @@
+use chrono::{DateTime, Utc};
+use crate::constants::*;
+use crate::Project;
+
+pub fn format_relative_time(time: DateTime<Utc>) -> String {
+    let now = Utc::now();
+    let duration = now.signed_duration_since(time);
+    
+    if duration.num_minutes() < 1 {
+        "방금 전".to_string()
+    } else if duration.num_minutes() < 60 {
+        format!("{}분 전", duration.num_minutes())
+    } else if duration.num_hours() < 24 {
+        format!("{}시간 전", duration.num_hours())
+    } else if duration.num_days() == 1 {
+        "어제".to_string()
+    } else if duration.num_days() < 7 {
+        format!("{}일 전", duration.num_days())
+    } else if duration.num_weeks() == 1 {
+        "1주일 전".to_string()
+    } else if duration.num_weeks() < 4 {
+        format!("{}주일 전", duration.num_weeks())
+    } else if duration.num_days() < 365 {
+        let months = duration.num_days() / 30;
+        if months == 1 {
+            "1달 전".to_string()
+        } else {
+            format!("{}달 전", months)
+        }
+    } else {
+        let years = duration.num_days() / 365;
+        if years == 1 {
+            "1년 전".to_string()
+        } else {
+            format!("{}년 전", years)
+        }
+    }
+}
+
+pub fn display_project_simple(project: &Project, access_time: Option<DateTime<Utc>>) {
+    let tags_display = if project.tags.is_empty() {
+        "".to_string()
+    } else {
+        format!("[{}]", project.tags.join(", "))
+    };
+    
+    let last_updated_display = if let Some(git_time) = project.git_updated_at {
+        format!("Git: {}", format_relative_time(git_time))
+    } else {
+        format!("PM: {}", format_relative_time(project.updated_at))
+    };
+    
+    let access_display = if let Some(access_time) = access_time {
+        format!(" (접근: {})", format_relative_time(access_time))
+    } else {
+        "".to_string()
+    };
+    
+    println!(
+        "{:<width_name$} {:<width_tags$} {:<width_time$}{}",
+        project.name,
+        tags_display,
+        last_updated_display,
+        access_display,
+        width_name = PROJECT_NAME_WIDTH,
+        width_tags = PROJECT_TAGS_WIDTH,
+        width_time = PROJECT_TIME_WIDTH
+    );
+}
+
+pub fn display_project_detailed(project: &Project, access_time: Option<DateTime<Utc>>, access_count: u32) {
+    println!("\n{}", project.name);
+    if !project.tags.is_empty() {
+        println!("  Tags: {}", project.tags.join(", "));
+    }
+    println!("  Path: {}", project.path.display());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+    println!("  ID: {}", project.id);
+    println!("  Created: {}", project.created_at.format("%Y-%m-%d %H:%M:%S"));
+    println!("  Updated: {}", project.updated_at.format("%Y-%m-%d %H:%M:%S"));
+    if let Some(git_time) = project.git_updated_at {
+        println!("  Git Updated: {} ({})", git_time.format("%Y-%m-%d %H:%M:%S"), format_relative_time(git_time));
+    }
+    if let Some(access_time) = access_time {
+        println!("  Last Accessed: {} ({})", access_time.format("%Y-%m-%d %H:%M:%S"), format_relative_time(access_time));
+    }
+    if access_count > 0 {
+        println!("  Access Count: {}", access_count);
+    }
+}
+
+pub fn display_project_list_header(count: usize) {
+    println!("📋 Active Projects ({} found)", count);
+}
+
+pub fn display_no_projects() {
+    println!("📋 No projects found");
+    println!("\n💡 {}", SUGGESTION_ADD_FIRST_PROJECT);
+}
+
+pub fn display_no_matches() {
+    println!("📋 No projects match your filters");
+    println!("\n💡 Try:");
+    println!("  - No filters: pm ls");
+    println!("  - Longer time period: pm ls -r 30d");
+    println!("  - Different tags: pm ls --tags-any frontend,backend");
+}
+
+pub fn display_switch_info(project_name: &str, access_count: u32, last_accessed: Option<DateTime<Utc>>) {
+    println!("🔄 Switching to project: {}", project_name);
+    println!("📊 Access count: {} times", access_count);
+    
+    if let Some(last_time) = last_accessed {
+        println!("⏰ Last accessed: {}", format_relative_time(last_time));
+    }
+}
+
+pub fn display_switch_success(project_path: &std::path::Path, no_editor: bool) {
+    println!("📂 Working directory: {}", project_path.display());
+    
+    if no_editor {
+        println!("✅ Project switched (editor not opened)");
+    } else {
+        println!("🚀 Opening editor...");
+    }
+}
+
+pub fn display_suggestions(suggestions: &[String]) {
+    if !suggestions.is_empty() {
+        println!("\n💡 Did you mean one of these?");
+        for suggestion in suggestions.iter().take(3) {
+            println!("  - {}", suggestion);
+        }
+    } else {
+        println!("\n💡 {}", SUGGESTION_USE_PM_LS);
+    }
+}
+
+pub fn display_error(context: &str, error: &str) {
+    eprintln!("❌ {}: {}", context, error);
+}
+
+pub fn display_warning(message: &str) {
+    eprintln!("⚠️  {}", message);
+}
+
+pub fn display_success(message: &str) {
+    println!("✅ {}", message);
+}
+
+pub fn display_info(message: &str) {
+    println!("💡 {}", message);
+}
+
+pub fn display_project_added(project_name: &str, tags: &[String]) {
+    println!("✅ Project '{}' added successfully!", project_name);
+    if !tags.is_empty() {
+        println!("🏷️  Tags: {}", tags.join(", "));
+    }
+}
+
+pub fn display_editor_error(error: &str) {
+    eprintln!("❌ Failed to execute editor '{}': {}", DEFAULT_EDITOR, error);
+    eprintln!("\n💡 Suggestions:");
+    eprintln!("  - {}", SUGGESTION_INSTALL_HELIX);
+    eprintln!("  - {}", SUGGESTION_USE_NO_EDITOR);
+    eprintln!("  - {}", SUGGESTION_SET_EDITOR_ENV);
+}
+
+pub fn display_init_success(github_username: &str, projects_root: &std::path::Path, config_path: &std::path::Path) {
+    println!("\n✅ {}", SUCCESS_PM_INITIALIZED);
+    println!("👤 GitHub username: {}", github_username);
+    println!("📁 Projects root: {}", projects_root.display());
+    println!("⚙️  Config file: {}", config_path.display());
+    println!("\n🎯 Next steps:");
+    println!("  pm add <path>     # Add your first project");
+    println!("  pm ls             # List projects");
+    println!("  pm s <name>       # Switch to project");
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum PmError {
+    ConfigLoadFailed,
+    ConfigSaveFailed,
+    InvalidPath,
+    ProjectNotFound,
+    ProjectPathNotFound,
+    DuplicateProject,
+    NoProjectsFound,
+    DirectoryChangeFailed,
+    DirectoryCreationFailed,
+    EditorLaunchFailed,
+    InitializationFailed,
+    TagOperationFailed,
+    ValidationFailed(String),
+    GitOperationFailed,
+}
+
+impl fmt::Display for PmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PmError::ConfigLoadFailed => write!(f, "Failed to load configuration"),
+            PmError::ConfigSaveFailed => write!(f, "Failed to save configuration"),
+            PmError::InvalidPath => write!(f, "Invalid project path"),
+            PmError::ProjectNotFound => write!(f, "Project not found"),
+            PmError::ProjectPathNotFound => write!(f, "Project path no longer exists"),
+            PmError::DuplicateProject => write!(f, "Project already exists"),
+            PmError::NoProjectsFound => write!(f, "No projects found"),
+            PmError::DirectoryChangeFailed => write!(f, "Failed to change directory"),
+            PmError::DirectoryCreationFailed => write!(f, "Failed to create directory"),
+            PmError::EditorLaunchFailed => write!(f, "Failed to launch editor"),
+            PmError::InitializationFailed => write!(f, "Failed to initialize PM"),
+            PmError::TagOperationFailed => write!(f, "Tag operation failed"),
+            PmError::ValidationFailed(msg) => write!(f, "Validation failed: {}", msg),
+            PmError::GitOperationFailed => write!(f, "Git operation failed"),
+        }
+    }
+}
+
+impl std::error::Error for PmError {}
+
+
+pub fn handle_error(error: anyhow::Error, context: &str) -> ! {
+    eprintln!("❌ {}: {}", context, error);
+    std::process::exit(1);
+}
+
+pub trait ErrorContext<T> {
+    fn with_pm_context(self, context: &str) -> Result<T, anyhow::Error>;
+}
+
+impl<T, E> ErrorContext<T> for Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn with_pm_context(self, context: &str) -> Result<T, anyhow::Error> {
+        self.map_err(|e| anyhow::Error::new(e).context(context.to_string()))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,22 @@
-use chrono::{DateTime, Utc, Duration};
+use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use uuid::Uuid;
-use anyhow::{Result, Context};
 
 mod config;
 mod utils;
 mod tag_commands;
+mod constants;
+mod display;
+mod validation;
+mod error;
+mod commands;
 
-use config::{get_config_path, load_config, save_config, Config};
-use utils::get_last_git_commit_time;
-use tag_commands::{add_tags, remove_tags, list_tags, show_tags};
+use config::load_config;
+use commands::{init, project, tag};
+use error::handle_error;
+use constants::*;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -161,188 +166,28 @@ enum TagAction {
     },
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-struct Project {
-    id: Uuid,
-    name: String,
-    path: PathBuf,
-    tags: Vec<String>,
-    description: Option<String>,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-    git_updated_at: Option<DateTime<Utc>>,
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Project {
+    pub id: Uuid,
+    pub name: String,
+    pub path: PathBuf,
+    pub tags: Vec<String>,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub git_updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
-struct MachineMetadata {
-    last_accessed: std::collections::HashMap<Uuid, DateTime<Utc>>,
-    access_counts: std::collections::HashMap<Uuid, u32>,
+pub struct MachineMetadata {
+    pub last_accessed: std::collections::HashMap<Uuid, DateTime<Utc>>,
+    pub access_counts: std::collections::HashMap<Uuid, u32>,
 }
 
-fn handle_error(error: anyhow::Error, context: &str) {
-    eprintln!("❌ {}: {}", context, error);
-    std::process::exit(1);
-}
 
-fn suggest_similar_projects(config: &Config, target: &str) -> Vec<String> {
-    config.projects.values()
-        .map(|p| &p.name)
-        .filter(|name| {
-            // Simple similarity check - contains substring or starts with same chars
-            name.to_lowercase().contains(&target.to_lowercase()) ||
-            target.to_lowercase().contains(&name.to_lowercase()) ||
-            name.chars().take(3).collect::<String>().to_lowercase() == 
-            target.chars().take(3).collect::<String>().to_lowercase()
-        })
-        .map(|s| s.clone())
-        .collect()
-}
 
-fn validate_path(path: &PathBuf) -> Result<PathBuf> {
-    if !path.exists() {
-        anyhow::bail!(
-            "Path does not exist: {}\n\n💡 Suggestions:\n  - Check if the path is correct\n  - Create the directory first: mkdir -p {}",
-            path.display(),
-            path.display()
-        );
-    }
 
-    if !path.is_dir() {
-        anyhow::bail!(
-            "Path is not a directory: {}\n\n💡 Please provide a directory path, not a file.",
-            path.display()
-        );
-    }
 
-    path.canonicalize()
-        .with_context(|| format!("Failed to resolve absolute path for: {}", path.display()))
-}
-
-async fn switch_to_project(config: &mut Config, name: &str, no_editor: bool) -> Result<(), String> {
-    if config.projects.is_empty() {
-        println!("📋 No projects found");
-        println!("\n💡 Add your first project with: pm add <path>");
-        return Err("No projects found".to_string());
-    }
-
-    if let Some(project) = config.find_project_by_name(name) {
-        let project_id = project.id;
-        let project_name = project.name.clone();
-        let project_path = project.path.clone();
-
-        // Check if project path still exists
-        if !project_path.exists() {
-            eprintln!("❌ Project path no longer exists: {}", project_path.display());
-            eprintln!("\n💡 Suggestions:");
-            eprintln!("  - Update the project path");
-            eprintln!("  - Remove the project: pm project remove {}", project_name);
-            return Err("Project path does not exist".to_string());
-        }
-
-        // Record access before switching
-        config.record_project_access(project_id);
-        
-        // Get access info for display
-        let (last_accessed, access_count) = config.get_project_access_info(project_id);
-        
-        println!("🔄 Switching to project: {}", project_name);
-        println!("📊 Access count: {} times", access_count);
-        
-        if let Some(last_time) = last_accessed {
-            let now = Utc::now();
-            let duration = now.signed_duration_since(last_time);
-            
-            if duration.num_minutes() < 60 {
-                println!("⏰ Last accessed: {} minutes ago", duration.num_minutes());
-            } else if duration.num_hours() < 24 {
-                println!("⏰ Last accessed: {} hours ago", duration.num_hours());
-            } else {
-                println!("⏰ Last accessed: {} days ago", duration.num_days());
-            }
-        }
-        
-        if let Err(e) = std::env::set_current_dir(&project_path) {
-            eprintln!("❌ Failed to change directory: {}", e);
-            eprintln!("   Path: {}", project_path.display());
-            return Err("Failed to change directory".to_string());
-        }
-        
-        // Save config with updated access tracking
-        if let Err(e) = save_config(&config).await {
-            eprintln!("⚠️  Failed to save access tracking: {}", e);
-            // Continue anyway, don't fail the switch operation
-        }
-        
-        println!("📂 Working directory: {}", project_path.display());
-
-        if !no_editor {
-            println!("🚀 Opening editor...");
-            let mut cmd = std::process::Command::new("hx");
-            match cmd.status() {
-                Ok(status) => {
-                    if !status.success() {
-                        eprintln!("⚠️  Editor exited with status: {}", status);
-                    }
-                },
-                Err(e) => {
-                    eprintln!("❌ Failed to execute editor 'hx': {}", e);
-                    eprintln!("\n💡 Suggestions:");
-                    eprintln!("  - Install Helix editor: https://helix-editor.com/");
-                    eprintln!("  - Use --no-editor flag to skip editor");
-                    eprintln!("  - Set EDITOR environment variable to your preferred editor");
-                }
-            }
-        } else {
-            println!("✅ Project switched (editor not opened)");
-        }
-
-        Ok(())
-    } else {
-        eprintln!("❌ Project not found: '{}'", name);
-        
-        let suggestions = suggest_similar_projects(&config, name);
-        if !suggestions.is_empty() {
-            eprintln!("\n💡 Did you mean one of these?");
-            for suggestion in suggestions.iter().take(3) {
-                eprintln!("  - {}", suggestion);
-            }
-        } else {
-            eprintln!("\n💡 Use 'pm ls' to see all available projects");
-        }
-        
-        Err("Project not found".to_string())
-    }
-}
-
-fn parse_time_duration(duration_str: &str) -> Result<Duration, String> {
-    if duration_str.is_empty() {
-        return Err("Duration cannot be empty".to_string());
-    }
-
-    let (number_part, unit_part) = if let Some(last_char) = duration_str.chars().last() {
-        if last_char.is_alphabetic() {
-            let (num_str, unit_str) = duration_str.split_at(duration_str.len() - 1);
-            (num_str, unit_str)
-        } else {
-            (duration_str, "d") // default to days
-        }
-    } else {
-        return Err("Invalid duration format".to_string());
-    };
-
-    let number: i64 = number_part.parse()
-        .map_err(|_| format!("Invalid number: {}", number_part))?;
-
-    match unit_part.to_lowercase().as_str() {
-        "s" | "sec" | "second" | "seconds" => Ok(Duration::seconds(number)),
-        "m" | "min" | "minute" | "minutes" => Ok(Duration::minutes(number)),
-        "h" | "hour" | "hours" => Ok(Duration::hours(number)),
-        "d" | "day" | "days" => Ok(Duration::days(number)),
-        "w" | "week" | "weeks" => Ok(Duration::weeks(number)),
-        "y" | "year" | "years" => Ok(Duration::days(number * 365)),
-        _ => Err(format!("Unknown time unit: {}. Use s, m, h, d, w, or y", unit_part))
-    }
-}
 
 #[tokio::main]
 async fn main() {
@@ -350,489 +195,78 @@ async fn main() {
 
     match &cli.command {
         Commands::Add { path, name, tags, description } => {
-            let mut config = match load_config().await {
-                Ok(config) => config,
-                Err(e) => {
-                    handle_error(e, "Failed to load configuration");
-                    return;
-                }
-            };
-
-            let resolved_path = if path.is_absolute() {
-                path.clone()
-            } else {
-                config.projects_root_dir.join(path)
-            };
-
-            let absolute_path = match validate_path(&resolved_path) {
-                Ok(path) => path,
-                Err(e) => {
-                    handle_error(e, "Invalid project path");
-                    return;
-                }
-            };
-
-            // Check for duplicate projects
-            if config.projects.values().any(|p| p.path == absolute_path) {
-                eprintln!("❌ Project already exists at path: {}", absolute_path.display());
-                eprintln!("\n💡 Use 'pm ls' to see all projects");
-                return;
-            }
-
-            let project_name = name.clone().unwrap_or_else(|| {
-                absolute_path.file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("unnamed-project")
-                    .to_string()
-            });
-
-            // Check for duplicate project names
-            if config.projects.values().any(|p| p.name == project_name) {
-                eprintln!("❌ Project with name '{}' already exists", project_name);
-                eprintln!("\n💡 Use a different name with: pm add {} --name <new-name>", path.display());
-                return;
-            }
-
-            println!("📂 Adding project at: {}", absolute_path.display());
-
-            let git_updated_at = match get_last_git_commit_time(&absolute_path) {
-                Ok(time) => time,
-                Err(_) => {
-                    println!("⚠️  Not a Git repository or no commits found");
-                    None
-                }
-            };
-
-            let project = Project {
-                id: Uuid::new_v4(),
-                name: project_name.clone(),
-                path: absolute_path.clone(),
-                tags: tags.clone(),
-                description: description.clone(),
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                git_updated_at,
-            };
-
-            config.add_project(project);
-            
-            if let Err(e) = save_config(&config).await {
-                handle_error(e, "Failed to save configuration");
-                return;
-            }
-
-            println!("✅ Project '{}' added successfully!", project_name);
-            if !tags.is_empty() {
-                println!("🏷️  Tags: {}", tags.join(", "));
+            if let Err(e) = project::handle_add(path, name, tags, description).await {
+                handle_error(e, ERROR_CONFIG_LOAD);
             }
         }
         Commands::List { tags, tags_any, recent, limit, detailed } => {
-            let mut config = match load_config().await {
-                Ok(config) => config,
-                Err(e) => {
-                    handle_error(e, "Failed to load configuration");
-                    return;
-                }
-            };
-
-            if config.projects.is_empty() {
-                println!("📋 No projects found");
-                println!("\n💡 Add your first project with: pm add <path>");
-                return;
-            }
-
-            let mut projects: Vec<&mut Project> = config.projects.values_mut().collect();
-
-            // Update git_updated_at for projects in the background
-            for project in projects.iter_mut() {
-                let needs_update = project.git_updated_at.is_none() || 
-                                   (Utc::now() - project.git_updated_at.unwrap()).num_hours() >= 1;
-                if needs_update {
-                    let project_path = project.path.clone();
-                    let project_id = project.id;
-                    tokio::spawn(async move {
-                        if let Ok(Some(git_time)) = get_last_git_commit_time(&project_path) {
-                            let mut config = load_config().await.unwrap();
-                            if let Some(p) = config.projects.get_mut(&project_id) {
-                                p.git_updated_at = Some(git_time);
-                                save_config(&config).await.unwrap();
-                            }
-                        }
-                    });
-                }
-            }
-
-            // Apply filters
-            let mut filtered_projects: Vec<&mut Project> = projects.into_iter().filter(|project| {
-                // Tags filter (AND logic - all tags must match)
-                if !tags.is_empty() {
-                    let project_tags: std::collections::HashSet<String> = project.tags.iter().cloned().collect();
-                    if !tags.iter().all(|tag| project_tags.contains(tag)) {
-                        return false;
-                    }
-                }
-
-                // Tags any filter (OR logic - any tag can match)
-                if !tags_any.is_empty() {
-                    let project_tags: std::collections::HashSet<String> = project.tags.iter().cloned().collect();
-                    if !tags_any.iter().any(|tag| project_tags.contains(tag)) {
-                        return false;
-                    }
-                }
-
-                // Recent filter
-                if let Some(recent_str) = recent {
-                    match parse_time_duration(recent_str) {
-                        Ok(duration) => {
-                            let cutoff = Utc::now() - duration;
-                            let last_activity = project.git_updated_at.unwrap_or(project.updated_at);
-                            if last_activity < cutoff {
-                                return false;
-                            }
-                        },
-                        Err(_) => {
-                            eprintln!("⚠️  Invalid time format: {}. Using default of 7 days.", recent_str);
-                            let cutoff = Utc::now() - Duration::days(7);
-                            let last_activity = project.git_updated_at.unwrap_or(project.updated_at);
-                            if last_activity < cutoff {
-                                return false;
-                            }
-                        }
-                    }
-                }
-
-                true
-            }).collect();
-
-            // Sort projects: git_updated_at (later), updated_at, created_at
-            filtered_projects.sort_by(|a, b| {
-                b.git_updated_at.cmp(&a.git_updated_at)
-                    .then_with(|| b.updated_at.cmp(&a.updated_at))
-                    .then_with(|| b.created_at.cmp(&a.created_at))
-            });
-
-            // Apply limit
-            if let Some(limit_count) = limit {
-                filtered_projects.truncate(*limit_count);
-            }
-
-            if filtered_projects.is_empty() {
-                println!("📋 No projects match your filters");
-                println!("\n💡 Try:");
-                if !tags.is_empty() {
-                    println!("  - Using fewer tags: pm ls -t {}", tags[0]);
-                }
-                if !tags_any.is_empty() {
-                    println!("  - Different tags: pm ls --tags-any {}", tags_any.join(","));
-                }
-                if recent.is_some() {
-                    println!("  - Longer time period: pm ls -r 30d");
-                }
-                println!("  - No filters: pm ls");
-                return;
-            }
-
-            println!("📋 Active Projects ({} found)", filtered_projects.len());
-            for project in filtered_projects {
-                if *detailed {
-                    // Detailed view
-                    println!("\n{}", project.name);
-                    if !project.tags.is_empty() {
-                        println!("  Tags: {}", project.tags.join(", "));
-                    }
-                    println!("  Path: {}", project.path.display());
-                    if let Some(desc) = &project.description {
-                        println!("  Description: {}", desc);
-                    }
-                    println!("  ID: {}", project.id);
-                    println!("  Created: {}", project.created_at.format("%Y-%m-%d %H:%M:%S"));
-                    println!("  Updated: {}", project.updated_at.format("%Y-%m-%d %H:%M:%S"));
-                    if let Some(git_time) = project.git_updated_at {
-                        println!("  Git Updated: {}", git_time.format("%Y-%m-%d %H:%M:%S"));
-                    }
-                } else {
-                    // Simple view
-                    let tags_display = if project.tags.is_empty() {
-                        "".to_string()
-                    } else {
-                        format!("[{}]", project.tags.join(", "))
-                    };
-                    let last_updated_display = if let Some(git_time) = project.git_updated_at {
-                        format!("Git: {}", git_time.format("%Y-%m-%d %H:%M"))
-                    } else {
-                        format!("PM: {}", project.updated_at.format("%Y-%m-%d %H:%M"))
-                    };
-                    println!(
-                        "{:<20} {:<30} {:<20}",
-                        project.name,
-                        tags_display,
-                        last_updated_display
-                    );
-                }
+            if let Err(e) = project::handle_list(tags, tags_any, recent, limit, *detailed).await {
+                handle_error(e, ERROR_CONFIG_LOAD);
             }
         }
         Commands::Switch { name, no_editor } => {
             let mut config = match load_config().await {
                 Ok(config) => config,
                 Err(e) => {
-                    handle_error(e, "Failed to load configuration");
+                    handle_error(e, ERROR_CONFIG_LOAD);
                     return;
                 }
             };
 
-            let _ = switch_to_project(&mut config, name, *no_editor).await;
+            if let Err(e) = project::handle_switch(&mut config, name, *no_editor).await {
+                handle_error(e, ERROR_PROJECT_NOT_FOUND);
+            }
         }
         Commands::Project(project_command) => match project_command {
             ProjectCommands::Add { path, name, tags, description } => {
-                let mut config = load_config().await.unwrap();
-
-                let resolved_path = if path.is_absolute() {
-                    path.clone()
-                } else {
-                    config.projects_root_dir.join(path)
-                };
-
-                let absolute_path = resolved_path.canonicalize().unwrap();
-                println!("Adding project at: {:?}", absolute_path);
-
-                let project_name = name.clone().unwrap_or_else(|| {
-                    absolute_path.file_name().unwrap().to_str().unwrap().to_string()
-                });
-
-                let project = Project {
-                    id: Uuid::new_v4(),
-                    name: project_name,
-                    path: absolute_path.clone(),
-                    tags: tags.clone(),
-                    description: description.clone(),
-                    created_at: Utc::now(),
-                    updated_at: Utc::now(),
-                    git_updated_at: get_last_git_commit_time(&absolute_path).unwrap(),
-                };
-
-                config.add_project(project);
-                save_config(&config).await.unwrap();
-
-                println!("✅ Project '{}' added successfully.", config.projects.get(&config.projects.keys().last().unwrap()).unwrap().name);
+                if let Err(e) = project::handle_add(path, name, tags, description).await {
+                    handle_error(e, ERROR_CONFIG_LOAD);
+                }
             }
             ProjectCommands::List { tags, tags_any, recent, limit, detailed } => {
-                let mut config = load_config().await.unwrap();
-                let mut projects: Vec<&mut Project> = config.projects.values_mut().collect();
-
-                // Update git_updated_at for projects in the background
-                for project in projects.iter_mut() {
-                    let needs_update = project.git_updated_at.is_none() || 
-                                       (Utc::now() - project.git_updated_at.unwrap()).num_hours() >= 1;
-                    if needs_update {
-                        let project_path = project.path.clone();
-                        let project_id = project.id;
-                        tokio::spawn(async move {
-                            if let Ok(Some(git_time)) = get_last_git_commit_time(&project_path) {
-                                let mut config = load_config().await.unwrap();
-                                if let Some(p) = config.projects.get_mut(&project_id) {
-                                    p.git_updated_at = Some(git_time);
-                                    save_config(&config).await.unwrap();
-                                }
-                            }
-                        });
-                    }
-                }
-
-                // Apply filters
-                let mut filtered_projects: Vec<&mut Project> = projects.into_iter().filter(|project| {
-                    // Tags filter (AND logic - all tags must match)
-                    if !tags.is_empty() {
-                        let project_tags: std::collections::HashSet<String> = project.tags.iter().cloned().collect();
-                        if !tags.iter().all(|tag| project_tags.contains(tag)) {
-                            return false;
-                        }
-                    }
-
-                    // Tags any filter (OR logic - any tag can match)
-                    if !tags_any.is_empty() {
-                        let project_tags: std::collections::HashSet<String> = project.tags.iter().cloned().collect();
-                        if !tags_any.iter().any(|tag| project_tags.contains(tag)) {
-                            return false;
-                        }
-                    }
-
-                    // Recent filter
-                    if let Some(recent_str) = recent {
-                        match parse_time_duration(recent_str) {
-                            Ok(duration) => {
-                                let cutoff = Utc::now() - duration;
-                                let last_activity = project.git_updated_at.unwrap_or(project.updated_at);
-                                if last_activity < cutoff {
-                                    return false;
-                                }
-                            },
-                            Err(_) => {
-                                eprintln!("⚠️  Invalid time format: {}. Using default of 7 days.", recent_str);
-                                let cutoff = Utc::now() - Duration::days(7);
-                                let last_activity = project.git_updated_at.unwrap_or(project.updated_at);
-                                if last_activity < cutoff {
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-
-                    true
-                }).collect();
-
-                // Sort projects: git_updated_at (later), updated_at, created_at
-                filtered_projects.sort_by(|a, b| {
-                    b.git_updated_at.cmp(&a.git_updated_at)
-                        .then_with(|| b.updated_at.cmp(&a.updated_at))
-                        .then_with(|| b.created_at.cmp(&a.created_at))
-                });
-
-                // Apply limit
-                if let Some(limit_count) = limit {
-                    filtered_projects.truncate(*limit_count);
-                }
-
-                println!("Active Projects ({} found)", filtered_projects.len());
-                for project in filtered_projects {
-                    if *detailed {
-                        // Detailed view
-                        println!("\n{}", project.name);
-                        if !project.tags.is_empty() {
-                            println!("  Tags: {}", project.tags.join(", "));
-                        }
-                        println!("  Path: {}", project.path.display());
-                        if let Some(desc) = &project.description {
-                            println!("  Description: {}", desc);
-                        }
-                        println!("  ID: {}", project.id);
-                        println!("  Created: {}", project.created_at.format("%Y-%m-%d %H:%M:%S"));
-                        println!("  Updated: {}", project.updated_at.format("%Y-%m-%d %H:%M:%S"));
-                        if let Some(git_time) = project.git_updated_at {
-                            println!("  Git Updated: {}", git_time.format("%Y-%m-%d %H:%M:%S"));
-                        }
-                    } else {
-                        // Simple view
-                        let tags_display = if project.tags.is_empty() {
-                            "".to_string()
-                        } else {
-                            format!("[{}]", project.tags.join(", "))
-                        };
-                        let last_updated_display = if let Some(git_time) = project.git_updated_at {
-                            format!("Git: {}", git_time.format("%Y-%m-%d %H:%M"))
-                        } else {
-                            format!("PM: {}", project.updated_at.format("%Y-%m-%d %H:%M"))
-                        };
-                        println!(
-                            "{:<20} {:<30} {:<20}",
-                            project.name,
-                            tags_display,
-                            last_updated_display
-                        );
-                    }
+                if let Err(e) = project::handle_list(tags, tags_any, recent, limit, *detailed).await {
+                    handle_error(e, ERROR_CONFIG_LOAD);
                 }
             }
             ProjectCommands::Switch { name, no_editor } => {
                 let mut config = match load_config().await {
                     Ok(config) => config,
                     Err(e) => {
-                        handle_error(e, "Failed to load configuration");
-                        return;
+                        handle_error(e, ERROR_CONFIG_LOAD);
                     }
                 };
 
-                let _ = switch_to_project(&mut config, name, *no_editor).await;
+                if let Err(e) = project::handle_switch(&mut config, name, *no_editor).await {
+                    handle_error(e, ERROR_PROJECT_NOT_FOUND);
+                }
             }
         },
         Commands::Tag { action } => match action {
             TagAction::Add { project_name, tags } => {
-                let mut config = load_config().await.unwrap();
-                add_tags(project_name, tags, &mut config).await.unwrap();
-                save_config(&config).await.unwrap();
+                if let Err(e) = tag::handle_tag_add(project_name, tags).await {
+                    handle_error(e, "Failed to add tags");
+                }
             }
             TagAction::Remove { project_name, tags } => {
-                let mut config = load_config().await.unwrap();
-                remove_tags(project_name, tags, &mut config).await.unwrap();
-                save_config(&config).await.unwrap();
+                if let Err(e) = tag::handle_tag_remove(project_name, tags).await {
+                    handle_error(e, "Failed to remove tags");
+                }
             }
             TagAction::List {} => {
-                let config = load_config().await.unwrap();
-                list_tags(&config).await.unwrap();
+                if let Err(e) = tag::handle_tag_list().await {
+                    handle_error(e, "Failed to list tags");
+                }
             }
             TagAction::Show { project_name } => {
-                let config = load_config().await.unwrap();
-                show_tags(project_name.as_deref(), &config).await.unwrap();
+                if let Err(e) = tag::handle_tag_show(project_name.as_deref()).await {
+                    handle_error(e, "Failed to show tags");
+                }
             }
         },
         Commands::Init {} => {
-            let config_path = match get_config_path() {
-                Ok(path) => path,
-                Err(e) => {
-                    handle_error(e, "Failed to get configuration path");
-                    return;
-                }
-            };
-
-            if config_path.exists() {
-                println!("✅ PM is already initialized");
-                println!("📁 Configuration file: {}", config_path.display());
-                println!("\n💡 To reinitialize, delete the config file first:");
-                println!("   rm {}", config_path.display());
-                return;
+            if let Err(e) = init::handle_init().await {
+                handle_error(e, "Failed to initialize PM");
             }
-
-            println!("🚀 Initializing PM...\n");
-
-            let github_username = match inquire::Text::new("GitHub username:")
-                .prompt() {
-                Ok(username) => username,
-                Err(e) => {
-                    eprintln!("❌ Failed to get GitHub username: {}", e);
-                    eprintln!("\n💡 You can also set this later in the config file");
-                    return;
-                }
-            };
-
-            let projects_root_dir_str = match inquire::Text::new("Projects root directory path:")
-                .with_default("~/workspace")
-                .prompt() {
-                Ok(path) => path,
-                Err(e) => {
-                    eprintln!("❌ Failed to get projects root directory: {}", e);
-                    return;
-                }
-            };
-
-            let projects_root_dir = PathBuf::from(shellexpand::tilde(&projects_root_dir_str).to_string());
-
-            // Validate and create the projects root directory if it doesn't exist
-            if !projects_root_dir.exists() {
-                println!("📁 Creating projects root directory: {}", projects_root_dir.display());
-                if let Err(e) = std::fs::create_dir_all(&projects_root_dir) {
-                    eprintln!("❌ Failed to create directory: {}", e);
-                    eprintln!("   Path: {}", projects_root_dir.display());
-                    return;
-                }
-            }
-
-            let config = Config {
-                github_username: github_username.clone(),
-                projects_root_dir: projects_root_dir.clone(),
-                ..Default::default()
-            };
-
-            if let Err(e) = save_config(&config).await {
-                handle_error(e, "Failed to save configuration");
-                return;
-            }
-
-            println!("\n✅ PM initialized successfully!");
-            println!("👤 GitHub username: {}", github_username);
-            println!("📁 Projects root: {}", projects_root_dir.display());
-            println!("⚙️  Config file: {}", config_path.display());
-            println!("\n🎯 Next steps:");
-            println!("  pm add <path>     # Add your first project");
-            println!("  pm ls             # List projects");
-            println!("  pm s <name>       # Switch to project");
         }
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,138 @@
+use std::path::PathBuf;
+use chrono::Duration;
+use anyhow::{Result, Context};
+use crate::constants::*;
+
+pub fn validate_path(path: &PathBuf) -> Result<PathBuf> {
+    if !path.exists() {
+        anyhow::bail!(
+            "Path does not exist: {}\n\n💡 Suggestions:\n  - {}\n  - Create the directory first: mkdir -p {}",
+            path.display(),
+            SUGGESTION_CHECK_PATH,
+            path.display()
+        );
+    }
+
+    if !path.is_dir() {
+        anyhow::bail!(
+            "Path is not a directory: {}\n\n💡 Please provide a directory path, not a file.",
+            path.display()
+        );
+    }
+
+    path.canonicalize()
+        .with_context(|| format!("Failed to resolve absolute path for: {}", path.display()))
+}
+
+pub fn parse_time_duration(duration_str: &str) -> Result<Duration, String> {
+    if duration_str.is_empty() {
+        return Err("Duration cannot be empty".to_string());
+    }
+
+    let (number_part, unit_part) = if let Some(last_char) = duration_str.chars().last() {
+        if last_char.is_alphabetic() {
+            let (num_str, unit_str) = duration_str.split_at(duration_str.len() - 1);
+            (num_str, unit_str)
+        } else {
+            (duration_str, "d") // default to days
+        }
+    } else {
+        return Err("Invalid duration format".to_string());
+    };
+
+    let number: i64 = number_part.parse()
+        .map_err(|_| format!("Invalid number: {}", number_part))?;
+
+    match unit_part.to_lowercase().as_str() {
+        "s" | "sec" | "second" | "seconds" => Ok(Duration::seconds(number)),
+        "m" | "min" | "minute" | "minutes" => Ok(Duration::minutes(number)),
+        "h" | "hour" | "hours" => Ok(Duration::hours(number)),
+        "d" | "day" | "days" => Ok(Duration::days(number)),
+        "w" | "week" | "weeks" => Ok(Duration::weeks(number)),
+        "y" | "year" | "years" => Ok(Duration::days(number * 365)),
+        _ => Err(format!("Unknown time unit: {}. Use s, m, h, d, w, or y", unit_part))
+    }
+}
+
+pub fn validate_project_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Project name cannot be empty".to_string());
+    }
+
+    if name.len() > 100 {
+        return Err("Project name too long (max 100 characters)".to_string());
+    }
+
+    // Check for invalid characters
+    let invalid_chars = ['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+    if name.chars().any(|c| invalid_chars.contains(&c)) {
+        return Err("Project name contains invalid characters".to_string());
+    }
+
+    Ok(())
+}
+
+pub fn validate_tags(tags: &[String]) -> Result<(), String> {
+    for tag in tags {
+        if tag.is_empty() {
+            return Err("Tag cannot be empty".to_string());
+        }
+
+        if tag.len() > 50 {
+            return Err(format!("Tag '{}' too long (max 50 characters)", tag));
+        }
+
+        // Check for invalid characters
+        if tag.contains(',') {
+            return Err(format!("Tag '{}' cannot contain commas", tag));
+        }
+
+        if tag.chars().any(|c| c.is_whitespace()) {
+            return Err(format!("Tag '{}' cannot contain whitespace", tag));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_time_duration() {
+        assert_eq!(parse_time_duration("30s").unwrap(), Duration::seconds(30));
+        assert_eq!(parse_time_duration("15m").unwrap(), Duration::minutes(15));
+        assert_eq!(parse_time_duration("2h").unwrap(), Duration::hours(2));
+        assert_eq!(parse_time_duration("7d").unwrap(), Duration::days(7));
+        assert_eq!(parse_time_duration("2w").unwrap(), Duration::weeks(2));
+        assert_eq!(parse_time_duration("1y").unwrap(), Duration::days(365));
+        
+        // Default to days if no unit specified
+        assert_eq!(parse_time_duration("7").unwrap(), Duration::days(7));
+        
+        // Error cases
+        assert!(parse_time_duration("").is_err());
+        assert!(parse_time_duration("abc").is_err());
+        assert!(parse_time_duration("7x").is_err());
+    }
+
+    #[test]
+    fn test_validate_project_name() {
+        assert!(validate_project_name("valid-project").is_ok());
+        assert!(validate_project_name("project_123").is_ok());
+        assert!(validate_project_name("").is_err());
+        assert!(validate_project_name("a".repeat(101).as_str()).is_err());
+        assert!(validate_project_name("invalid/name").is_err());
+        assert!(validate_project_name("invalid:name").is_err());
+    }
+
+    #[test]
+    fn test_validate_tags() {
+        assert!(validate_tags(&["rust".to_string(), "cli".to_string()]).is_ok());
+        assert!(validate_tags(&["".to_string()]).is_err());
+        assert!(validate_tags(&["a".repeat(51)]).is_err());
+        assert!(validate_tags(&["invalid,tag".to_string()]).is_err());
+        assert!(validate_tags(&["invalid tag".to_string()]).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `pm init` command for initial setup with GitHub username and projects root
- Implement comprehensive access tracking system for project usage analytics
- Add filtering system with short flags and time units support
- Modularize codebase with constants and improved separation of concerns
- Update documentation to reflect Rust project structure

## Changes
- **Core Features**: pm init command, access tracking, advanced filtering
- **Code Organization**: Better separation with constants module
- **Documentation**: Updated README for Rust project structure
- **CLI Enhancement**: Short flags (-t, -r, -l, -d) and time units (s, m, h, d, w, y)

## Test plan
- [ ] Test `pm init` command with various inputs
- [ ] Verify access tracking functionality
- [ ] Test all filtering options and time units
- [ ] Verify project listing and switching

🤖 Generated with [Claude Code](https://claude.ai/code)