### PR TITLE
feat: Add cross-platform GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+  build:
+    needs: create-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-pc-windows-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Prepare binary
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          if [[ "${{ matrix.target }}" == *"windows"* ]]; then
+            binary_name="pm-${{ matrix.target }}.exe"
+            cp pm.exe "../../../$binary_name"
+          else
+            binary_name="pm-${{ matrix.target }}"
+            cp pm "../../../$binary_name"
+          fi
+          echo "BINARY_NAME=$binary_name" >> $GITHUB_ENV
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./${{ env.BINARY_NAME }}
+          asset_name: ${{ env.BINARY_NAME }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated cross-platform releases only
- Support for 5 target platforms: Linux (x86_64, ARM64), Windows, macOS (Intel, Apple Silicon)
- Uses cross-compilation with `cross` tool for efficient builds on single Ubuntu runner
- Automatic release creation when version tags are pushed

## Changes
- `.github/workflows/release.yml` - Single file addition only

## Test plan
- [ ] Push a test tag to verify workflow execution
- [ ] Verify all 5 platform binaries are generated correctly
- [ ] Test binaries on respective platforms

🤖 Generated with [Claude Code](https://claude.ai/code)