### PR TITLE
feat: Force XDG config path and remove legacy support

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,8 +4,9 @@ pub const CONFIG_FILENAME: &str = "config.yml";
 pub const CONFIG_SCHEMA_PATH: &str = "schemas/config.schema.json";
 pub const CONFIG_VERSION: &str = "1.0";
 
-// Legacy support
-pub const LEGACY_CONFIG_FILENAME: &str = "config.json";
+// Config paths (XDG Base Directory Specification)
+pub const CONFIG_DIR_NAME: &str = ".config";
+pub const CONFIG_SUBDIR_NAME: &str = "pm";
 
 // Default values
 pub const DEFAULT_WORKSPACE_DIR: &str = "~/workspace";


### PR DESCRIPTION
## Summary
- Remove all legacy migration code and JSON config support
- Force config file location to `~/.config/pm/config.yml` only (XDG compliance)
- Remove platform-specific Application Support path usage
- Simplify configuration loading logic

## Changes Made
### Config Path Standardization
- Updated `get_config_path()` to use XDG Base Directory specification
- Added `CONFIG_DIR_NAME` and `CONFIG_SUBDIR_NAME` constants
- Removed `LEGACY_CONFIG_FILENAME` constant

### Legacy Code Removal
- Removed `try_load_legacy_config()` function
- Removed `try_migrate_platform_config()` function
- Removed `get_legacy_platform_config_path()` function
- Removed `LegacyConfig` struct and JSON support
- Simplified `load_config()` to only check XDG location

### Display Consistency
- All commands now consistently show `~/.config/pm/config.yml`
- Eliminated confusion between old/new config locations

## Test Results
✅ `pm init` shows correct XDG path: `/Users/x/.config/pm/config.yml`
✅ All commands consistently use XDG location
✅ No legacy migration messages or warnings
✅ Old Application Support location no longer used

## Breaking Changes
- **Config Migration**: Users with configs in old locations will need to manually move them to `~/.config/pm/config.yml`
- **No Backward Compatibility**: Legacy JSON configs are no longer supported

🤖 Generated with [Claude Code](https://claude.ai/code)