### PR TITLE
feat: Add Ctrl-C interrupt handling for interactive prompts

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -205,8 +205,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
         }
     }
 
-    println!("\n🎉 {} initialized successfully!", APP_NAME.to_uppercase());
-    println!("📖 Use 'pm --help' to see all available commands");
+    println!("\n📖 Use 'pm --help' to see all available commands");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Implement graceful Ctrl-C interrupt handling for all interactive prompts
- Add proper error handling for user cancellation across all commands
- Fix duplicate initialization success message

## Changes Made
- **Enhanced Error Handling**: Added `OperationCancelled` error type and `handle_inquire_error()` function
- **Updated All Interactive Prompts**: Modified 25 prompt calls across 3 command files to handle Ctrl-C gracefully
- **User Experience**: Users can now press Ctrl-C to cancel any interactive operation without crashes
- **Bug Fix**: Removed duplicate "PM initialized successfully" message

## Updated Files
- `src/error.rs`: Added OperationCancelled error and handle_inquire_error function
- `src/commands/init.rs`: Updated 9 prompt calls with interrupt handling + fixed duplicate message
- `src/commands/config.rs`: Updated 14 prompt calls with interrupt handling
- `src/commands/project.rs`: Updated 2 prompt calls with interrupt handling

## Test Plan
- [x] Build passes without errors
- [x] All interactive commands now respond to Ctrl-C properly
- [x] Graceful cancellation with "💭 Operation cancelled" message
- [x] No more duplicate initialization messages

🤖 Generated with [Claude Code](https://claude.ai/code)