### PR TITLE
feat: Add comprehensive Ctrl-C interrupt handling and GitHub repository browsing

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -160,23 +160,45 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
             println!("\n🌐 GitHub integration ready!");
             println!("💡 Use 'pm load <owner>/<repo>' to clone and add repositories");
 
-            // Optionally prompt for first repository
-            let load_repo = handle_inquire_error(inquire::Confirm::new("Would you like to clone a repository now?")
-                .with_default(false)
-                .prompt())
-                .unwrap_or(false);
+            // Offer repository options
+            let repo_options = vec![
+                "📋 Browse and select from my repositories",
+                "📝 Enter specific repository manually",
+                "⏭️  Skip for now",
+            ];
 
-            if load_repo {
-                let repo = handle_inquire_error(Text::new("Repository (<owner>/<repo> format):")
-                    .with_help_message("e.g., microsoft/vscode or your-username/my-project")
+            let repo_choice = handle_inquire_error(
+                Select::new("How would you like to add repositories?", repo_options)
                     .prompt()
-)?;
+            )?;
 
-                if let Err(e) = project::handle_load(&repo, None).await {
-                    display_warning(&format!("Failed to load repository: {}", e));
-                    println!("💡 You can try again with: pm load {}", repo);
-                } else {
-                    projects_added += 1;
+            match repo_choice {
+                "📋 Browse and select from my repositories" => {
+                    match project::handle_github_repo_selection(&github_username).await {
+                        Ok(count) => {
+                            projects_added += count;
+                        }
+                        Err(e) => {
+                            display_warning(&format!("Failed to fetch repositories: {}", e));
+                            println!("💡 You can browse repositories later with a custom command");
+                        }
+                    }
+                }
+                "📝 Enter specific repository manually" => {
+                    let repo = handle_inquire_error(Text::new("Repository (<owner>/<repo> format):")
+                        .with_help_message("e.g., microsoft/vscode or your-username/my-project")
+                        .prompt()
+                    )?;
+
+                    if let Err(e) = project::handle_load(&repo, None).await {
+                        display_warning(&format!("Failed to load repository: {}", e));
+                        println!("💡 You can try again with: pm load {}", repo);
+                    } else {
+                        projects_added += 1;
+                    }
+                }
+                _ => {
+                    // Skip for now
                 }
             }
         }
@@ -195,22 +217,45 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
 
             // Then offer GitHub integration
             println!("\n🌐 GitHub integration ready!");
-            let load_repo = handle_inquire_error(inquire::Confirm::new("Would you like to clone a repository now?")
-                .with_default(false)
-                .prompt())
-                .unwrap_or(false);
+            
+            let repo_options = vec![
+                "📋 Browse and select from my repositories",
+                "📝 Enter specific repository manually",
+                "⏭️  Skip for now",
+            ];
 
-            if load_repo {
-                let repo = handle_inquire_error(Text::new("Repository (<owner>/<repo> format):")
-                    .with_help_message("e.g., microsoft/vscode or your-username/my-project")
+            let repo_choice = handle_inquire_error(
+                Select::new("How would you like to add repositories?", repo_options)
                     .prompt()
-)?;
+            )?;
 
-                if let Err(e) = project::handle_load(&repo, None).await {
-                    display_warning(&format!("Failed to load repository: {}", e));
-                    println!("💡 You can try again with: pm load {}", repo);
-                } else {
-                    projects_added += 1;
+            match repo_choice {
+                "📋 Browse and select from my repositories" => {
+                    match project::handle_github_repo_selection(&github_username).await {
+                        Ok(count) => {
+                            projects_added += count;
+                        }
+                        Err(e) => {
+                            display_warning(&format!("Failed to fetch repositories: {}", e));
+                            println!("💡 You can browse repositories later with a custom command");
+                        }
+                    }
+                }
+                "📝 Enter specific repository manually" => {
+                    let repo = handle_inquire_error(Text::new("Repository (<owner>/<repo> format):")
+                        .with_help_message("e.g., microsoft/vscode or your-username/my-project")
+                        .prompt()
+                    )?;
+
+                    if let Err(e) = project::handle_load(&repo, None).await {
+                        display_warning(&format!("Failed to load repository: {}", e));
+                        println!("💡 You can try again with: pm load {}", repo);
+                    } else {
+                        projects_added += 1;
+                    }
+                }
+                _ => {
+                    // Skip for now
                 }
             }
         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -142,6 +142,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
     // Step 4: Execute setup actions based on mode
     let mut projects_added = 0;
     let mut scan_failed = false;
+    let mut repo_selection_cancelled = false;
     match selected_mode {
         InitMode::Detect => {
             println!("\n🔍 Auto-detecting existing repositories...");
@@ -183,6 +184,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                             if let Some(pm_error) = e.downcast_ref::<PmError>() {
                                 if matches!(pm_error, PmError::OperationCancelled) {
                                     println!("📭 No repositories selected from GitHub");
+                                    repo_selection_cancelled = true;
                                     // Don't propagate error - this is expected behavior
                                 } else {
                                     display_warning(&format!("Failed to fetch repositories: {}", e));
@@ -251,6 +253,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                             if let Some(pm_error) = e.downcast_ref::<PmError>() {
                                 if matches!(pm_error, PmError::OperationCancelled) {
                                     println!("📭 No repositories selected from GitHub");
+                                    repo_selection_cancelled = true;
                                     // Don't propagate error - this is expected behavior
                                 } else {
                                     display_warning(&format!("Failed to fetch repositories: {}", e));
@@ -292,8 +295,8 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
         println!("  pm ls             # List your projects");
         println!("  pm s <name>       # Switch to project");
         println!("  pm add <path>     # Add more projects");
-    } else if !scan_failed {
-        // Only show next steps if scan didn't fail
+    } else if !scan_failed && !repo_selection_cancelled {
+        // Only show next steps if scan didn't fail and user didn't cancel repo selection
         match selected_mode {
             InitMode::None => {
                 println!("\n🎯 Next steps:");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -182,11 +182,16 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                             // Check if this is a user cancellation (Ctrl-C)
                             if let Some(pm_error) = e.downcast_ref::<PmError>() {
                                 if matches!(pm_error, PmError::OperationCancelled) {
-                                    return Err(e); // Propagate cancellation up
+                                    println!("📭 No repositories selected from GitHub");
+                                    // Don't propagate error - this is expected behavior
+                                } else {
+                                    display_warning(&format!("Failed to fetch repositories: {}", e));
+                                    println!("💡 You can browse repositories later with a custom command");
                                 }
+                            } else {
+                                display_warning(&format!("Failed to fetch repositories: {}", e));
+                                println!("💡 You can browse repositories later with a custom command");
                             }
-                            display_warning(&format!("Failed to fetch repositories: {}", e));
-                            println!("💡 You can browse repositories later with a custom command");
                         }
                     }
                 }
@@ -245,11 +250,16 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                             // Check if this is a user cancellation (Ctrl-C)
                             if let Some(pm_error) = e.downcast_ref::<PmError>() {
                                 if matches!(pm_error, PmError::OperationCancelled) {
-                                    return Err(e); // Propagate cancellation up
+                                    println!("📭 No repositories selected from GitHub");
+                                    // Don't propagate error - this is expected behavior
+                                } else {
+                                    display_warning(&format!("Failed to fetch repositories: {}", e));
+                                    println!("💡 You can browse repositories later with a custom command");
                                 }
+                            } else {
+                                display_warning(&format!("Failed to fetch repositories: {}", e));
+                                println!("💡 You can browse repositories later with a custom command");
                             }
-                            display_warning(&format!("Failed to fetch repositories: {}", e));
-                            println!("💡 You can browse repositories later with a custom command");
                         }
                     }
                 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -141,6 +141,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
 
     // Step 4: Execute setup actions based on mode
     let mut projects_added = 0;
+    let mut scan_failed = false;
     match selected_mode {
         InitMode::Detect => {
             println!("\n🔍 Auto-detecting existing repositories...");
@@ -149,6 +150,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                     projects_added += count;
                 }
                 Err(e) => {
+                    scan_failed = true;
                     display_warning(&format!("Auto-detection failed: {}", e));
                     println!("💡 You can run 'pm scan' later to detect repositories");
                 }
@@ -186,6 +188,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                     projects_added += count;
                 }
                 Err(e) => {
+                    scan_failed = true;
                     display_warning(&format!("Auto-detection failed: {}", e));
                 }
             }
@@ -222,7 +225,8 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
         println!("  pm ls             # List your projects");
         println!("  pm s <name>       # Switch to project");
         println!("  pm add <path>     # Add more projects");
-    } else {
+    } else if !scan_failed {
+        // Only show next steps if scan didn't fail
         match selected_mode {
             InitMode::None => {
                 println!("\n🎯 Next steps:");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -167,7 +167,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                 .unwrap_or(false);
 
             if load_repo {
-                let repo = handle_inquire_error(Text::new("Repository (owner/repo format):")
+                let repo = handle_inquire_error(Text::new("Repository (<owner>/<repo> format):")
                     .with_help_message("e.g., microsoft/vscode or your-username/my-project")
                     .prompt()
 )?;
@@ -201,7 +201,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                 .unwrap_or(false);
 
             if load_repo {
-                let repo = handle_inquire_error(Text::new("Repository (owner/repo format):")
+                let repo = handle_inquire_error(Text::new("Repository (<owner>/<repo> format):")
                     .with_help_message("e.g., microsoft/vscode or your-username/my-project")
                     .prompt()
 )?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -158,7 +158,7 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
         }
         InitMode::Load => {
             println!("\n🌐 GitHub integration ready!");
-            println!("💡 Use 'pm load owner/repo' to clone and add repositories");
+            println!("💡 Use 'pm load <owner>/<repo>' to clone and add repositories");
 
             // Optionally prompt for first repository
             let load_repo = handle_inquire_error(inquire::Confirm::new("Would you like to clone a repository now?")
@@ -232,13 +232,13 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                 println!("\n🎯 Next steps:");
                 println!("  pm add <path>     # Add your first project");
                 println!("  pm scan           # Scan for existing repositories");
-                println!("  pm load owner/repo # Clone from GitHub");
+                println!("  pm load <owner>/<repo> # Clone from GitHub");
             }
             _ => {
                 println!("\n🎯 Next steps:");
                 println!("  pm add <path>     # Add your first project");
                 println!("  pm scan           # Try scanning again");
-                println!("  pm load owner/repo # Clone from GitHub");
+                println!("  pm load <owner>/<repo> # Clone from GitHub");
             }
         }
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -179,6 +179,12 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                             projects_added += count;
                         }
                         Err(e) => {
+                            // Check if this is a user cancellation (Ctrl-C)
+                            if let Some(pm_error) = e.downcast_ref::<PmError>() {
+                                if matches!(pm_error, PmError::OperationCancelled) {
+                                    return Err(e); // Propagate cancellation up
+                                }
+                            }
                             display_warning(&format!("Failed to fetch repositories: {}", e));
                             println!("💡 You can browse repositories later with a custom command");
                         }
@@ -236,6 +242,12 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
                             projects_added += count;
                         }
                         Err(e) => {
+                            // Check if this is a user cancellation (Ctrl-C)
+                            if let Some(pm_error) = e.downcast_ref::<PmError>() {
+                                if matches!(pm_error, PmError::OperationCancelled) {
+                                    return Err(e); // Propagate cancellation up
+                                }
+                            }
                             display_warning(&format!("Failed to fetch repositories: {}", e));
                             println!("💡 You can browse repositories later with a custom command");
                         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -313,7 +313,10 @@ pub async fn handle_init(mode: Option<&InitMode>) -> Result<()> {
         }
     }
 
-    println!("\n📖 Use 'pm --help' to see all available commands");
+    // Only show help message if user didn't cancel repository selection
+    if !repo_selection_cancelled {
+        println!("\n📖 Use 'pm --help' to see all available commands");
+    }
 
     Ok(())
 }

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -390,7 +390,7 @@ struct GitRepoInfo {
     remote_url: Option<String>,
 }
 
-pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<()> {
+pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<usize> {
     let config = load_config().await?;
 
     // Determine scan directory
@@ -484,7 +484,7 @@ pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<()>
 
     if repositories.is_empty() {
         println!("❌ No repositories found in {}", scan_dir.display());
-        return Ok(());
+        return Ok(0);
     }
 
     // Filter out already tracked projects
@@ -498,7 +498,7 @@ pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<()>
 
     if new_repos.is_empty() {
         println!("✅ All found repositories are already tracked by PM");
-        return Ok(());
+        return Ok(0);
     }
 
     println!("📦 Found {} new repositories:", new_repos.len());
@@ -516,7 +516,7 @@ pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<()>
                 println!("    🌐 {}", url.bright_black());
             }
         }
-        return Ok(());
+        return Ok(0);
     }
 
     // Interactive selection
@@ -530,14 +530,14 @@ pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<()>
 
     if options.is_empty() {
         println!("✅ No new repositories to add");
-        return Ok(());
+        return Ok(0);
     }
 
     let selection = handle_inquire_error(MultiSelect::new("Select repositories to add to PM:", options).prompt())?;
 
     if selection.is_empty() {
         println!("❌ No repositories selected");
-        return Ok(());
+        return Ok(0);
     }
 
     // Add selected repositories
@@ -581,7 +581,7 @@ pub async fn handle_scan(directory: Option<&Path>, show_all: bool) -> Result<()>
     save_config(&config).await?;
     println!("🎉 Successfully added {} repositories to PM", added_count);
 
-    Ok(())
+    Ok(added_count)
 }
 
 pub async fn handle_load(repo: &str, directory: Option<&Path>) -> Result<()> {

--- a/src/display.rs
+++ b/src/display.rs
@@ -204,8 +204,4 @@ pub fn display_init_success(
     println!("👤 GitHub username: {}", github_username);
     println!("📁 Projects root: {}", projects_root.display());
     println!("⚙️  Config file: {}", config_path.display());
-    println!("\n🎯 Next steps:");
-    println!("  pm add <path>     # Add your first project");
-    println!("  pm ls             # List projects");
-    println!("  pm s <name>       # Switch to project");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod tag_commands;
 mod utils;
 mod validation;
 
+use error::PmError;
+
 use commands::config::ExportFormat;
 use commands::{config as config_cmd, init, project, tag};
 use config::load_config;
@@ -612,6 +614,13 @@ async fn main() {
             }
 
             if let Err(e) = project::handle_github_repo_selection(target_username).await {
+                // Check if this is a user cancellation (Ctrl-C)
+                if let Some(pm_error) = e.downcast_ref::<PmError>() {
+                    if matches!(pm_error, PmError::OperationCancelled) {
+                        // Gracefully exit on cancellation
+                        std::process::exit(0);
+                    }
+                }
                 handle_config_error(e);
             }
         }


### PR DESCRIPTION
## Summary
This PR adds comprehensive Ctrl-C interrupt handling for all interactive prompts and implements GitHub repository browsing functionality with GitHub CLI integration.

## Key Features

### 🔧 Ctrl-C Interrupt Handling
- **All Interactive Prompts**: Added graceful Ctrl-C handling to 25+ prompts across init, config, and project commands
- **Clean Cancellation**: Shows "💭 Operation cancelled" message and exits cleanly without panics
- **Error Propagation**: Proper `OperationCancelled` error handling throughout the call stack

### 🌐 GitHub Repository Integration
- **GitHub CLI Authentication**: Leverages existing `gh auth` instead of manual token management
- **Repository Browsing**: New `pm browse` command and init integration to select from all user repositories
- **Private Repository Support**: Automatic private repo access when authenticated with GitHub CLI
- **Visual Repository Info**: Shows privacy (🔒/🌐), fork status (🍴), language, and descriptions

### 🎯 Improved User Experience
- **Conditional Next Steps**: Only shows relevant guidance based on initialization results
- **Clean Cancellation Flow**: Repository selection cancellation shows minimal, appropriate messaging
- **Dynamic Placeholders**: Uses `<owner>/<repo>` format to clearly indicate user input needed
- **Contextual Help**: Provides specific guidance based on GitHub CLI installation/auth status

## Implementation Details

### Files Modified
- **`src/error.rs`**: Added `OperationCancelled` error type and `handle_inquire_error()` function
- **`src/commands/init.rs`**: Enhanced with repository browsing options and cancellation handling
- **`src/commands/config.rs`**: Updated all 14 prompt calls with interrupt handling
- **`src/commands/project.rs`**: Added GitHub API integration and repository selection interface
- **`src/main.rs`**: Added `pm browse` command with proper cancellation handling

### New Commands
- **`pm browse`**: Browse and select repositories from GitHub (uses configured username)
- **`pm browse -u <username>`**: Browse repositories for specific user

### Enhanced Init Flow
Users now get three options during GitHub integration:
1. 📋 **Browse and select from my repositories** - New interactive selection
2. 📝 **Enter specific repository manually** - Original manual input
3. ⏭️ **Skip for now** - Continue without adding repositories

## Test Plan
- [x] All interactive commands respond to Ctrl-C properly
- [x] GitHub CLI authentication detection works correctly
- [x] Repository browsing shows correct metadata (private/public, forks, languages)
- [x] Cancellation during init shows appropriate minimal messaging
- [x] Build passes without errors
- [x] Repository selection supports multiple selection and cloning

## Breaking Changes
None - all changes are additive or improve existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)