### PR TITLE
🏗️ Architecture: Remove Default Workspace Concept

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -36,19 +36,6 @@ pub async fn handle_init() -> Result<()> {
         PathBuf::from(shellexpand::tilde(&config_input).to_string())
     };
 
-    // Step 2: Projects directory configuration
-    let projects_root_dir = {
-        let default_workspace = dirs::home_dir()
-            .map(|home| home.join("workspace"))
-            .unwrap_or_else(|| PathBuf::from("~/workspace"));
-
-        let dir_input = handle_inquire_error(Text::new("Projects root directory:")
-            .with_default(&default_workspace.to_string_lossy())
-            .with_help_message("Where your projects will be stored (press Enter for default)")
-            .prompt())?;
-
-        PathBuf::from(shellexpand::tilde(&dir_input).to_string())
-    };
 
     // Step 3: Editor configuration
     let editor_options = vec![
@@ -85,18 +72,6 @@ pub async fn handle_init() -> Result<()> {
         .with_default(true)
         .prompt())?;
 
-    // Create the projects root directory if it doesn't exist
-    if !projects_root_dir.exists() {
-        println!(
-            "\n📁 Creating projects root directory: {}",
-            projects_root_dir.display()
-        );
-        if let Err(e) = std::fs::create_dir_all(&projects_root_dir) {
-            display_error("Failed to create directory", &e.to_string());
-            println!("   Path: {}", projects_root_dir.display());
-            return Err(PmError::DirectoryCreationFailed.into());
-        }
-    }
 
     // Create the config directory if it doesn't exist
     if !config_dir_path.exists() {
@@ -115,7 +90,6 @@ pub async fn handle_init() -> Result<()> {
     let config = Config {
         version: crate::constants::CONFIG_VERSION.to_string(),
         config_path: config_dir_path.clone(),
-        projects_root_dir: projects_root_dir.clone(),
         editor,
         settings: ConfigSettings {
             auto_open_editor,
@@ -127,14 +101,14 @@ pub async fn handle_init() -> Result<()> {
     };
 
     save_config(&config).await?;
-    display_init_success(&config_dir_path, &projects_root_dir, &config_path);
+    display_init_success(&config_dir_path, &config_path);
 
     // Show next steps for using PM
     println!("\n🎯 Next steps:");
-    println!("  pm project add <path>          # Add your first project");
-    println!("  pm github scan                 # Scan for existing repositories");
-    println!("  pm github clone <owner>/<repo> # Clone specific repository");
-    println!("  pm github clone                # Browse and select repositories");
+    println!("  pm add <path>          # Add your first project");
+    println!("  pm scan                # Scan for existing repositories");
+    println!("  pm clone <owner>/<repo> # Clone specific repository");
+    println!("  pm clone               # Browse and select repositories");
     
     println!("\n📖 Use 'pm --help' to see all available commands");
 

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -44,7 +44,7 @@ pub async fn handle_add(
     let resolved_path = if path.is_absolute() {
         path.clone()
     } else {
-        config.projects_root_dir.join(path)
+        std::env::current_dir()?.join(path)
     };
 
     // Check if directory exists
@@ -953,8 +953,8 @@ async fn load_repository_internal(repo: &str, directory: Option<&Path>, show_pro
     let target_dir = if let Some(dir) = directory {
         dir.to_path_buf()
     } else {
-        // Default: <root_dir>/<owner>/<repo>
-        config.projects_root_dir.join(&owner).join(&repo_name)
+        // Default: <current_dir>/<owner>/<repo>
+        std::env::current_dir()?.join(&owner).join(&repo_name)
     };
 
     if target_dir.exists() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,11 +25,6 @@ pub struct Config {
         example = "config_path_example"
     )]
     pub config_path: PathBuf,
-    #[schemars(
-        description = "Root directory where your projects are located",
-        example = "projects_root_example"
-    )]
-    pub projects_root_dir: PathBuf,
     #[serde(default = "default_editor")]
     #[schemars(description = "Default editor command", example = "editor_example")]
     pub editor: String,
@@ -84,9 +79,6 @@ fn config_path_example() -> &'static str {
     "~/.config/pm"
 }
 
-fn projects_root_example() -> &'static str {
-    "~/workspace"
-}
 
 fn editor_example() -> &'static str {
     "hx"
@@ -97,7 +89,6 @@ impl Default for Config {
         Self {
             version: CONFIG_VERSION.to_string(),
             config_path: PathBuf::new(),
-            projects_root_dir: PathBuf::new(),
             editor: String::new(), // 빈 문자열로 초기화
             settings: ConfigSettings::default(),
             projects: HashMap::new(),
@@ -245,18 +236,11 @@ impl Config {
     }
 }
 
-fn validate_config(config: &Config) -> Result<()> {
+fn validate_config(_config: &Config) -> Result<()> {
     // For now, we'll do basic validation without JSON schema
     // Full schema validation will be implemented in Phase 2
 
-    // Basic validations
-    if !config.projects_root_dir.exists() {
-        return Err(anyhow::anyhow!(
-            "Projects root directory does not exist: {}",
-            config.projects_root_dir.display()
-        ));
-    }
-
+    // Basic validations would go here
     Ok(())
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -197,11 +197,9 @@ pub fn display_editor_error(error: &str) {
 
 pub fn display_init_success(
     config_dir: &std::path::Path,
-    projects_root: &std::path::Path,
     config_file_path: &std::path::Path,
 ) {
     println!("\n✅ {}", SUCCESS_PM_INITIALIZED);
     println!("📂 Config directory: {}", config_dir.display());
-    println!("📁 Projects root: {}", projects_root.display());
     println!("⚙️  Config file: {}", config_file_path.display());
 }


### PR DESCRIPTION
## 🏗️ Architecture: Remove Default Workspace Concept

### Summary
Eliminates the rigid workspace concept, allowing projects to be managed from any location.

### Changes
- 🗑️ Remove `projects_root_dir` field from Config struct
- 🔧 Update initialization process to remove workspace setup
- 🛠️ Modify configuration validation logic
- 📁 Allow project management from current directory
- 🔄 Update project.rs to use `std::env::current_dir()` instead of workspace

### Breaking Changes
- ⚠️ Configuration format change (removes projects_root_dir)
- ⚠️ Users will need to re-run `pm init`

### Benefits
- ✨ More flexible project management
- 🎯 Simplified configuration
- 📂 Work from any directory

### Testing
- [x] `pm init` works without workspace prompts
- [x] Configuration validation passes
- [x] Existing projects remain accessible
- [x] `cargo check` passes

### Files Changed
- `src/config.rs` - Remove projects_root_dir field and validation
- `src/commands/config.rs` - Update configuration management
- `src/commands/init.rs` - Remove workspace setup prompts
- `src/commands/project.rs` - Use current directory instead of workspace
- `src/display.rs` - Update display functions

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>